### PR TITLE
Cancel button functionality changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -540,8 +540,7 @@ def query_radar_files():
         radar = radar.upper()
         args = [radar, f'{sa.event_start_str}', str(sa.event_duration), str(False)]
         e = utils.exec_script(sa.nexrad_script_path, args)
-        if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
-            return e
+        return e
 
 
 def run_hodo_script(args) -> None:
@@ -696,7 +695,8 @@ def run_with_cancel_button():
         # way to handle this. Calls NexradDownloader but passes download=False to only
         # query AWS for expected files
         e = query_radar_files()
-        if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+
+        if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
             return
 
         for _r, radar in enumerate(sa.radar_list):
@@ -715,9 +715,10 @@ def run_with_cancel_button():
             )
             args = [radar, str(sa.event_start_str), str(sa.event_duration), str(True)]
             e = utils.exec_script(sa.nexrad_script_path, args)
+            print('HERERER', e)
             # This section is what forces the callback to end if the cancel button was hit.
             # The returncode for the exception equals the SIGTERM value (usually 15).
-            if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+            if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
                 return
             
             # Munger
@@ -725,7 +726,7 @@ def run_with_cancel_button():
             args = [radar, str(sa.playback_start_str), str(sa.event_duration), str(sa.simulation_seconds_shift),
                     new_radar]
             e = utils.exec_script(sa.l2munger_script_path, args)
-            if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+            if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
                 return
             print(f"Munge for {new_radar} completed ...")
             
@@ -741,14 +742,14 @@ def run_with_cancel_button():
     print("Running obs script...")
     args = [str(sa.lat), str(sa.lon), sa.event_start_str, str(sa.event_duration)]
     e = utils.exec_script(sa.obs_script_path, args)
-    if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+    if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
 
     print("Running NSE scripts...")
     args = [str(sa.event_start_time), str(sa.event_duration), str(sa.scripts_path), 
             str(sa.data_dir), str(sa.placefiles_dir)]
     e = utils.exec_script(sa.nse_script_path, args)
-    if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+    if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
     
     # Since there will always be a timeshift associated with a simulation, this
@@ -773,7 +774,7 @@ def run_with_cancel_button():
         args = [radar, sa.new_radar, asos_one, asos_two, 
                 str(sa.simulation_seconds_shift)]
         e = utils.exec_script(sa.hodo_script_path, args)
-        if e and e.returncode in [signal.SIGTERM, -1*signal.SIGTERM]:
+        if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
             return
         print("Hodograph script completed ...")
 

--- a/app.py
+++ b/app.py
@@ -695,7 +695,6 @@ def run_with_cancel_button():
         # way to handle this. Calls NexradDownloader but passes download=False to only
         # query AWS for expected files
         e = query_radar_files()
-
         if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
             return
 
@@ -714,9 +713,8 @@ def run_with_cancel_button():
                 f"Nexrad Downloader - {radar}, {sa.event_start_str}, {str(sa.event_duration)}"
             )
             args = [radar, str(sa.event_start_str), str(sa.event_duration), str(True)]
+            
             e = utils.exec_script(sa.nexrad_script_path, args)
-            # This section is what forces the callback to end if the cancel button was hit.
-            # The returncode for the exception equals the SIGTERM value (usually 15).
             if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
                 return
             
@@ -724,9 +722,11 @@ def run_with_cancel_button():
             print(f"Munge from {radar} to {new_radar}...")
             args = [radar, str(sa.playback_start_str), str(sa.event_duration), str(sa.simulation_seconds_shift),
                     new_radar]
+            
             e = utils.exec_script(sa.l2munger_script_path, args)
             if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
                 return
+            
             print(f"Munge for {new_radar} completed ...")
             
             # this gives the user some radar data to poll while other scripts are running
@@ -740,6 +740,7 @@ def run_with_cancel_button():
 
     print("Running obs script...")
     args = [str(sa.lat), str(sa.lon), sa.event_start_str, str(sa.event_duration)]
+
     e = utils.exec_script(sa.obs_script_path, args)
     if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
@@ -747,6 +748,7 @@ def run_with_cancel_button():
     print("Running NSE scripts...")
     args = [str(sa.event_start_time), str(sa.event_duration), str(sa.scripts_path), 
             str(sa.data_dir), str(sa.placefiles_dir)]
+    
     e = utils.exec_script(sa.nse_script_path, args)
     if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
@@ -772,9 +774,11 @@ def run_with_cancel_button():
         # Execute hodograph script
         args = [radar, sa.new_radar, asos_one, asos_two, 
                 str(sa.simulation_seconds_shift)]
+        
         e = utils.exec_script(sa.hodo_script_path, args)
         if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
             return
+        
         print("Hodograph script completed ...")
 
         try:

--- a/app.py
+++ b/app.py
@@ -784,7 +784,7 @@ def run_with_cancel_button():
     
 
 @app.callback(
-    Output('show_script_progress', 'children'),
+    Output('show_script_progress', 'children', allow_duplicate=True),
     [Input('run_scripts', 'n_clicks')],
     prevent_initial_call=True,
     running=[
@@ -831,9 +831,10 @@ def cancel_scripts(n_clicks):
     Output('radar_status', 'value'),
     Output('hodo_status', 'value'),
     Output('model_table', 'data'),
-    Output('status-output', 'children'),
+    Output('show_script_progress', 'children', allow_duplicate=True),
     [Input('directory_monitor', 'n_intervals')],
-    prevent_initial_call=True)
+    prevent_initial_call=True
+)
 def monitor(_n):
     """
     This function is called every second by the directory_monitor interval. It checks the

--- a/app.py
+++ b/app.py
@@ -715,7 +715,6 @@ def run_with_cancel_button():
             )
             args = [radar, str(sa.event_start_str), str(sa.event_duration), str(True)]
             e = utils.exec_script(sa.nexrad_script_path, args)
-            print('HERERER', e)
             # This section is what forces the callback to end if the cancel button was hit.
             # The returncode for the exception equals the SIGTERM value (usually 15).
             if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:

--- a/layout_components.py
+++ b/layout_components.py
@@ -369,7 +369,6 @@ simulation_clock = html.Div([
                 style={'text-align':'center'},),
                 #simulation_clock_slider,
 
-        html.Div(id='status-output', style=feedback),
         html.Div(id='clock-output', style=feedback),
 
         ], id='clock-container', style={'padding':'1em', 'vertical-align':'middle'}),

--- a/utils.py
+++ b/utils.py
@@ -19,11 +19,14 @@ def exec_script(script_path, args):
     if 'C:\\' in dir_parts:
         PYTHON = r"C:\\Users\\lee.carlaw\\environments\\cloud-radar\\Scripts\python.exe"
 
+    error_dict = {'returncode': -9999}
     try:
         subprocess.run([PYTHON, script_path] + args, check=True)
     except Exception as e:
         print(f"Error running {script_path}: {e}")
-        return e
+        error_dict['returncode'] = e.returncode
+
+    return error_dict
     
 
 def get_app_processes():


### PR DESCRIPTION
Relatively minor changes in this PR which attempt to address syntax/highlighting issues with initial e.returncode output.

- Define dictionary error_dict within function ```utils.exec_script``` to always return a value to the main app.  Previously, if no errors were encountered or the cancel button was not clicked during a script's execution, variable ```e``` didn't exist (even as "None").  This should be more verbose now. 
- Alter syntax within ```app.py``` to check ```if e['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:```. 
- Utilizes the ```show_script_progress``` div (under the cancel button) instead of ```status-output``` which was created in the last pull request. 