### PR TITLE
August updates 4

### DIFF
--- a/app.py
+++ b/app.py
@@ -782,22 +782,27 @@ def monitor(_n):
     # Need to put this list and utils.cancel_all scripts_list into __init__ or somewhere
     # similar. Finds running processes, determines if they're associated with this app, 
     # and outputs text at the bottom. 
-    scripts_list = ["Nexrad.py", "nse.py", "get_data.py", "process.py", 
-                    "hodo_plot.py", "munger.py", "wgrib2", "obs_placefile.py"]
+    scripts_list = ["scripts.Nexrad", "scripts.nse", "get_data.py", "process.py", 
+                    "scripts.hodo_plot", "scripts.munger", "wgrib2", "scripts.obs_placefile"]
     processes = utils.get_app_processes()
     screen_output = ""
     seen_scripts = []
     for p in processes:
-        name = p['cmdline'][1].rsplit('/', 1)
-        if len(name) > 1: name = name[1]
-        if p['name'] == 'wgrib2':
-            name = 'wgrib2'
-      
-        if name in scripts_list and name not in seen_scripts:
-            runtime = time.time() - p['create_time']
-            #screen_output += f"{name}: {p['status']} for {round(runtime,1)} s. "
-            screen_output += f"{name}: running for {round(runtime,1)} s. "
-            seen_scripts.append(name)
+        # We only care about scripts executed by the application, which now have the form
+        # ['python', '-m', 'scripts.XXXX', args]
+        if len(p['cmdline']) > 2:
+            name = p['cmdline'][2].rsplit('/', 1)
+            if len(name) > 1: name = name[1]
+            if p['name'] == 'wgrib2':
+                name = 'wgrib2'
+
+            name = name[0]
+
+            if name in scripts_list and name not in seen_scripts:
+                runtime = time.time() - p['create_time']
+                #screen_output += f"{name}: {p['status']} for {round(runtime,1)} s. "
+                screen_output += f"{name}: running for {round(runtime,1)} s. "
+                seen_scripts.append(name)
 
     # Radar file download status
     radar_dl_completion, radar_files = utils.radar_monitor(sa)

--- a/app.py
+++ b/app.py
@@ -775,34 +775,32 @@ def cancel_scripts(n_clicks) -> None:
 )
 def monitor(_n):
     """
-    This function is called every second by the directory_monitor interval. It checks the
-    status of the radar and hodograph scripts and reports the status to the user.
+    This function is called every second by the directory_monitor interval. It (1) checks 
+    the status of the various scripts and reports them to the front-end application and 
+    (2) monitors the completion status of the scripts. 
     """
 
-    # Need to put this list and utils.cancel_all scripts_list into __init__ or somewhere
-    # similar. Finds running processes, determines if they're associated with this app, 
-    # and outputs text at the bottom. 
+    # Scripts executed as modules are scripts.XX. get_data and process are called by nse.py. 
     scripts_list = ["scripts.Nexrad", "scripts.nse", "get_data.py", "process.py", 
                     "scripts.hodo_plot", "scripts.munger", "wgrib2", "scripts.obs_placefile"]
     processes = utils.get_app_processes()
     screen_output = ""
     seen_scripts = []
     for p in processes:
-        # We only care about scripts executed by the application, which now have the form
-        # ['python', '-m', 'scripts.XXXX', args]
-        if len(p['cmdline']) > 2:
-            name = p['cmdline'][2].rsplit('/', 1)
-            if len(name) > 1: name = name[1]
+        name = p['cmdline'][1].rsplit('/', 1)[-1]
+
+        # Scripts executed as python modules will be like [python, -m, script.name]
+        if p['cmdline'][1] == '-m':
+            name = p['cmdline'][2].rsplit('/', 1)[-1]
+            
+            #if len(name) > 1: name = name[1]
             if p['name'] == 'wgrib2':
                 name = 'wgrib2'
 
-            name = name[0]
-
-            if name in scripts_list and name not in seen_scripts:
-                runtime = time.time() - p['create_time']
-                #screen_output += f"{name}: {p['status']} for {round(runtime,1)} s. "
-                screen_output += f"{name}: running for {round(runtime,1)} s. "
-                seen_scripts.append(name)
+        if name in scripts_list and name not in seen_scripts:
+            runtime = time.time() - p['create_time']
+            screen_output += f"{name}: running for {round(runtime,1)} s. "
+            seen_scripts.append(name)
 
     # Radar file download status
     radar_dl_completion, radar_files = utils.radar_monitor(sa)

--- a/app.py
+++ b/app.py
@@ -779,25 +779,21 @@ def monitor(_n):
     the status of the various scripts and reports them to the front-end application and 
     (2) monitors the completion status of the scripts. 
     """
-
-    # Scripts executed as modules are scripts.XX. get_data and process are called by nse.py. 
-    scripts_list = ["scripts.Nexrad", "scripts.nse", "get_data.py", "process.py", 
-                    "scripts.hodo_plot", "scripts.munger", "wgrib2", "scripts.obs_placefile"]
     processes = utils.get_app_processes()
     screen_output = ""
     seen_scripts = []
     for p in processes:
-        name = p['cmdline'][1].rsplit('/', 1)[-1]
+        # Returns get_data or process (the two scripts launched by nse.py)
+        name = p['cmdline'][1].rsplit('/')[-1].rsplit('.')[0]
 
         # Scripts executed as python modules will be like [python, -m, script.name]
         if p['cmdline'][1] == '-m':
-            name = p['cmdline'][2].rsplit('/', 1)[-1]
-            
-            #if len(name) > 1: name = name[1]
+            # Should return Nexrad, munger, nse, etc.
+            name = p['cmdline'][2].rsplit('/')[-1].rsplit('.')[-1]
             if p['name'] == 'wgrib2':
                 name = 'wgrib2'
 
-        if name in scripts_list and name not in seen_scripts:
+        if name in cfg.scripts_list and name not in seen_scripts:
             runtime = time.time() - p['create_time']
             screen_output += f"{name}: running for {round(runtime,1)} s. "
             seen_scripts.append(name)

--- a/config.py
+++ b/config.py
@@ -61,3 +61,7 @@ LOG_DIR = DATA_DIR / 'logs'
 os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(HODO_IMAGES, exist_ok=True)
 os.makedirs(PLACEFILES_DIR, exist_ok=True)
+
+# 
+scripts_list = ["Nexrad", "munger", "obs_placefile", "nse", "wgrib2", 
+                "get_data", "process", "hodo_plot"]

--- a/scripts/Nexrad.py
+++ b/scripts/Nexrad.py
@@ -18,16 +18,16 @@ import boto3
 import botocore
 from botocore.client import Config
 
+from config import RADAR_DIR
 
-
-BASE_DIR = Path('/data/cloud-radar-server')
+#BASE_DIR = Path('/data/cloud-radar-server')
 # In order to get this work on my dev and work laptop
-if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
-    parts = Path.cwd().parts
-    idx = parts.index('cloud-radar-server')
-    BASE_DIR =  Path(*parts[0:idx+1])
+#if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
+#    parts = Path.cwd().parts
+#    idx = parts.index('cloud-radar-server')
+#    BASE_DIR =  Path(*parts[0:idx+1])
 
-RADAR_DIR = BASE_DIR / 'data' / 'radar'
+#RADAR_DIR = BASE_DIR / 'data' / 'radar'
 
 class NexradDownloader:
     """

--- a/scripts/hodo_plot.py
+++ b/scripts/hodo_plot.py
@@ -17,7 +17,10 @@ import sys
 import warnings
 from multiprocessing import Pool, freeze_support
 from pathlib import Path
-import hodo_resources as hr
+
+from config import RADAR_DIR, HODO_IMAGES
+import scripts.hodo_resources as hr
+
 from dotenv import load_dotenv
 load_dotenv()
 API_TOKEN = os.getenv("HODO_PLOT_TOKEN")
@@ -39,9 +42,9 @@ except:
     asos_two = None
 
 timeshift_seconds = int(sys.argv[5])
-BASE_DIR = Path('/data/cloud-radar-server')
-RADAR_DIR = BASE_DIR / 'data' / 'radar'
-HODO_IMAGES = BASE_DIR / 'assets'/ 'hodographs'
+#BASE_DIR = Path('/data/cloud-radar-server')
+#RADAR_DIR = BASE_DIR / 'data' / 'radar'
+#HODO_IMAGES = BASE_DIR / 'assets'/ 'hodographs'
 
 THIS_RADAR = RADAR_DIR / radar_id
 os.makedirs(THIS_RADAR, exist_ok=True)

--- a/scripts/munger.py
+++ b/scripts/munger.py
@@ -21,19 +21,19 @@ from datetime import datetime, timedelta, timezone
 import time
 import pytz
 
-
-BASE_DIR = Path('/data/cloud-radar-server')
+from config import RADAR_DIR, POLLING_DIR, L2MUNGER_FILEPATH, DEBZ_FILEPATH
+#BASE_DIR = Path('/data/cloud-radar-server')
 
 # In order to get this work on my dev and work laptop
-if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
-    parts = Path.cwd().parts
-    idx = parts.index('cloud-radar-server')
-    BASE_DIR =  Path(*parts[0:idx+1])
+#if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
+#    parts = Path.cwd().parts
+#    idx = parts.index('cloud-radar-server')
+#    BASE_DIR =  Path(*parts[0:idx+1])
 
-RADAR_DIR = BASE_DIR / 'data' / 'radar'
-POLLING_DIR = BASE_DIR / 'assets' / 'polling'
-L2MUNGER_FILEPATH = BASE_DIR / 'scripts' / 'l2munger'
-DEBZ_FILEPATH = BASE_DIR / 'scripts' / 'debz.py'
+#RADAR_DIR = BASE_DIR / 'data' / 'radar'
+#POLLING_DIR = BASE_DIR / 'assets' / 'polling'
+#L2MUNGER_FILEPATH = BASE_DIR / 'scripts' / 'l2munger'
+#DEBZ_FILEPATH = BASE_DIR / 'scripts' / 'debz.py'
 
 class Munger():
     """

--- a/scripts/obs_placefile.py
+++ b/scripts/obs_placefile.py
@@ -16,6 +16,7 @@ import math
 from datetime import datetime, timedelta
 import pytz
 import requests
+from config import PLACEFILES_DIR
 from dotenv import load_dotenv
 load_dotenv()
 API_TOKEN = os.getenv("SYNOPTIC_API_TOKEN")
@@ -34,14 +35,14 @@ rwis_t_zoom = 75
 gray = '180 180 180'
 white= '255 255 255'
 
-BASE_DIR = Path('/data/cloud-radar-server')
+#BASE_DIR = Path('/data/cloud-radar-server')
 # In order to get this work on my dev and work laptop
-if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
-    parts = Path.cwd().parts
-    idx = parts.index('cloud-radar-server')
-    BASE_DIR =  Path(*parts[0:idx+1])
+#if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
+#    parts = Path.cwd().parts
+#    idx = parts.index('cloud-radar-server')
+#    BASE_DIR =  Path(*parts[0:idx+1])
 
-PLACEFILES_DIR = BASE_DIR / 'assets' / 'placefiles'
+#PLACEFILES_DIR = BASE_DIR / 'assets' / 'placefiles'
 
 net = "1,2,96,162"
 variables = 'air_temp,dew_point_temperature,wind_speed,wind_direction,wind_gust,visibility,road_temp'

--- a/scripts/update_dir_list.py
+++ b/scripts/update_dir_list.py
@@ -10,13 +10,15 @@ from pathlib import Path
 from datetime import datetime
 import pytz
 
-BASE_DIR = Path('/data/cloud-radar-server')
-if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
-    parts = Path.cwd().parts
-    idx = parts.index('cloud-radar-server')
-    BASE_DIR =  Path(*parts[0:idx+1])
+from config import POLLING_DIR
 
-POLLING_DIR = BASE_DIR / 'assets' / 'polling'
+#BASE_DIR = Path('/data/cloud-radar-server')
+#if sys.platform.startswith('darwin') or sys.platform.startswith('win'):
+#    parts = Path.cwd().parts
+#    idx = parts.index('cloud-radar-server')
+#    BASE_DIR =  Path(*parts[0:idx+1])
+
+#POLLING_DIR = BASE_DIR / 'assets' / 'polling'
 
 class UpdateDirList():
     """

--- a/scripts/update_hodo_page.py
+++ b/scripts/update_hodo_page.py
@@ -8,11 +8,13 @@ import sys
 from datetime import datetime
 import pytz
 
-HODO_DIR = '/data/cloud-radar-server/assets/hodographs'
-HODOGRAPHS_PAGE = '/data/cloud-radar-server/assets/hodographs.html'
+from config import HODOGRAPHS_DIR, HODOGRAPHS_PAGE
+
+#HODO_DIR = '/data/cloud-radar-server/assets/hodographs'
+#HODOGRAPHS_PAGE = '/data/cloud-radar-server/assets/hodographs.html'
 dir_parts = Path.cwd().parts
 if 'C:\\' in dir_parts:
-    HODO_DIR = 'C:/data/scripts/cloud-radar-server/assets/hodographs'
+    HODOGRAPHS_DIR = 'C:/data/scripts/cloud-radar-server/assets/hodographs'
     HODOGRAPHS_PAGE = 'C:/data/scripts/cloud-radar-server/assets/hodographs.html'
     link_base = "http://localhost:8050/assets"
     cloud = False
@@ -68,7 +70,7 @@ class UpdateHodoHTML():
         Returns a list of valid hodographs based on the current playback time
         """
         valid_hodo_list = []
-        image_files = [f for f in os.listdir(HODO_DIR) if f.endswith('.png') or f.endswith('.jpg')]
+        image_files = [f for f in os.listdir(HODOGRAPHS_DIR) if f.endswith('.png') or f.endswith('.jpg')]
         
         for filename in image_files:
             file_time = datetime.strptime(filename[-19:-4], '%Y%m%d_%H%M%S').replace(tzinfo=pytz.UTC).timestamp()

--- a/utils.py
+++ b/utils.py
@@ -23,8 +23,14 @@ def exec_script(script_path, args):
 
     output = {}
     try:
-        process = subprocess.Popen([PYTHON, script_path] + args, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+        # Execute scripts as python module to allow config import from higher-level dir:
+        # python -m scripts.script-name
+        parts = script_path.parts
+        arg = f"{script_path.parts[-2]}.{parts[-1]}".replace(".py", "")
+        process = subprocess.Popen([PYTHON, '-m', arg] + args, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+        #process = subprocess.Popen([PYTHON, script_path] + args, stdout=subprocess.PIPE,
+        #                           stderr=subprocess.PIPE)
         output['stdout'], output['stderr'] = process.communicate()
         output['returncode'] = process.returncode
     except Exception as e:

--- a/utils.py
+++ b/utils.py
@@ -60,10 +60,6 @@ def cancel_all(sa):
     This function is invoked when the user clicks the Cancel button in the app. See
     app.cancel_scripts.
     """
-    # Should move this somewhere else, maybe into the __init__ function? These are 
-    # the cancelable scripts
-    scripts_list = ["Nexrad.py", "nse.py", "get_data.py", "process.py",
-                    "hodo_plot.py", "munger.py", "obs_placefile.py"]
     processes = get_app_processes()
 
     # ******************************************************************************
@@ -75,16 +71,20 @@ def cancel_all(sa):
     # shouldn't be?
     # ******************************************************************************
     for process in processes:
-        if any(x in process['cmdline'][1] for x in scripts_list) or \
-            ('wgrib2' in process['cmdline'][0]):
+        name = process['cmdline'][1].rsplit('/')[-1].rsplit('.')[0]
+        if process['cmdline'][1] == '-m':
+            name = process['cmdline'][2].rsplit('/')[-1].rsplit('.')[-1]
+        if process['name'] == 'wgrib2': name = 'wgrib2'
+
+        if name in cfg.scripts_list:
             sa.log.info(
-                f"Killing process: {process['cmdline'][1]} with pid: {process['pid']}"
+                f"Killing process: {name} with pid: {process['pid']}"
             ) 
             os.kill(process['pid'], signal.SIGTERM)
         
         if len(process['cmdline']) >= 3 and 'multiprocessing' in process['cmdline'][2]:
             sa.log.info(
-                f"Killing process: {process['cmdline'][1]} with pid: {process['pid']}"
+                f"Killing process: {name} with pid: {process['pid']}"
             ) 
             os.kill(process['pid'], signal.SIGTERM)
 

--- a/utils.py
+++ b/utils.py
@@ -77,15 +77,11 @@ def cancel_all(sa):
         if process['name'] == 'wgrib2': name = 'wgrib2'
 
         if name in cfg.scripts_list:
-            sa.log.info(
-                f"Killing process: {name} with pid: {process['pid']}"
-            ) 
+            sa.log.info(f"Killing process: {name} with pid: {process['pid']}") 
             os.kill(process['pid'], signal.SIGTERM)
         
         if len(process['cmdline']) >= 3 and 'multiprocessing' in process['cmdline'][2]:
-            sa.log.info(
-                f"Killing process: {name} with pid: {process['pid']}"
-            ) 
+            sa.log.info(f"Killing spawned multi-process with pid: {process['pid']}") 
             os.kill(process['pid'], signal.SIGTERM)
 
 


### PR DESCRIPTION
PR broadcasts `config.py` within the top-level directory to the various files within the `scripts` directory (such as `Nexrad.py`, `nse.py`, etc.) by executing these as python modules.  This is accomplished in `utils.exec_script`:

```
parts = script_path.parts
arg = f"{script_path.parts[-2]}.{parts[-1]}".replace(".py", "")
process = subprocess.Popen([PYTHON, '-m', arg] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
```

Each script is executed as `python -m scripts.script_name` which allows config to be imported from the higher-level directory (without needing relative imports or appending to `sys.path`.

Alterations were needed for `app.monitor` and `utils.cancel_all` to handle the slight change in process nomenclature.  Have not seen any issues testing this on the mac, windows, or aws instance. Everything appears to work as expected out of the box. 