### PR TITLE
Timeout Error Fix

### DIFF
--- a/scripts/hodo_plot.py
+++ b/scripts/hodo_plot.py
@@ -105,19 +105,40 @@ def mesowest_get_sfcwind(api_args):
     """
     station = api_args["stid"]
     api_request_url = os.path.join(API_ROOT, "stations/nearesttime")
-    req = requests.get(api_request_url, params=api_args, timeout=10)
-    jas_ts = req.json()
-    #wnspd = None
-    #wndir = None
-    wnspd = ''
-    wndir = ''
-    for s in range(0,len(jas_ts['STATION'])):
-        try:
-            station = jas_ts['STATION'][s]
-            wnspd = station['OBSERVATIONS']['wind_speed_value_1']['value']
-            wndir = station['OBSERVATIONS']['wind_direction_value_1']['value']
-        except:
-            pass
+    try:
+        req = requests.get(api_request_url, params=api_args, timeout=10)
+	jas_ts = req.json()
+	#wnspd = None
+	#wndir = None
+	wnspd = ''
+	wndir = ''
+	for s in range(0,len(jas_ts['STATION'])):
+	    try:
+		station = jas_ts['STATION'][s]
+		wnspd = station['OBSERVATIONS']['wind_speed_value_1']['value']
+		wndir = station['OBSERVATIONS']['wind_direction_value_1']['value']
+	    except:
+		pass
+    except requests.ReadTimeout:
+	try:
+	    req = requests.get(api_request_url, params=api_args, timeout=10)
+	    jas_ts = req.json()
+	    #wnspd = None
+	    #wndir = None
+	    wnspd = ''
+    	    wndir = ''
+	    for s in range(0,len(jas_ts['STATION'])):
+		try:
+		    station = jas_ts['STATION'][s]
+		    wnspd = station['OBSERVATIONS']['wind_speed_value_1']['value']
+		    wndir = station['OBSERVATIONS']['wind_direction_value_1']['value']
+		except:
+		    pass
+	except requests.ReadTimeout:
+	    wnspd = None
+	    wndir = None
+	    sfc_status = 'None'
+
     return wnspd, wndir
 
 def create_hodos(filename):

--- a/scripts/hodo_plot.py
+++ b/scripts/hodo_plot.py
@@ -105,7 +105,13 @@ def mesowest_get_sfcwind(api_args):
     """
     station = api_args["stid"]
     api_request_url = os.path.join(API_ROOT, "stations/nearesttime")
-    req = requests.get(api_request_url, params=api_args, timeout=10)
+    try:
+	req = requests.get(api_request_url, params=api_args, timeout=10)
+    except:
+	try:
+	    req = requests.get(api_request_url, params=api_args, timeout=30)
+	except:
+            sfc_status = 'None'
     jas_ts = req.json()
     #wnspd = None
     #wndir = None

--- a/scripts/hodo_plot.py
+++ b/scripts/hodo_plot.py
@@ -105,13 +105,7 @@ def mesowest_get_sfcwind(api_args):
     """
     station = api_args["stid"]
     api_request_url = os.path.join(API_ROOT, "stations/nearesttime")
-    try:
-	req = requests.get(api_request_url, params=api_args, timeout=10)
-    except:
-	try:
-	    req = requests.get(api_request_url, params=api_args, timeout=30)
-	except:
-            sfc_status = 'None'
+    req = requests.get(api_request_url, params=api_args, timeout=10)
     jas_ts = req.json()
     #wnspd = None
     #wndir = None


### PR DESCRIPTION
Add error handling for timeout errors from Synoptic API using the following method.

1) Try to run the original request for data.
2) If the request fails try again with a longer timeout period.
3) Upon 2 failures, abort the attempt. Set surface winds to none so they are not plotted. Surface winds will be unavailable for this timestep.