### PR TITLE
Polling refresh

### DIFF
--- a/layout_components.py
+++ b/layout_components.py
@@ -497,9 +497,14 @@ pause_resume_playback_btn = dbc.Col(html.Div([dbc.Button('Pause Playback', size=
                                                          disabled=True, n_clicks=0)],
                                              className="d-grid gap-2 col-12 mx-auto"))
 
+refresh_polling_btn = dbc.Col(html.Div([dbc.Button('Refresh Polling Times', size="lg",
+                                                         id='refresh_polling_btn',
+                                                         disabled=False, n_clicks=0)],
+                                             className="d-grid gap-2 col-12 mx-auto"))
+
 playback_buttons_container = dbc.Container(
     html.Div([dbc.Row([start_playback_btn,
-                       pause_resume_playback_btn])]))
+                       pause_resume_playback_btn, refresh_polling_btn])]))
 
 playback_start_label = html.Div(
     children="Simulation Start Time", style=time_headers)

--- a/layout_components.py
+++ b/layout_components.py
@@ -499,7 +499,7 @@ pause_resume_playback_btn = dbc.Col(html.Div([dbc.Button('Pause Playback', size=
 
 refresh_polling_btn = dbc.Col(html.Div([dbc.Button('Refresh Polling Times', size="lg",
                                                          id='refresh_polling_btn',
-                                                         disabled=False, n_clicks=0)],
+                                                         disabled=True, n_clicks=0)],
                                              className="d-grid gap-2 col-12 mx-auto"))
 
 playback_buttons_container = dbc.Container(

--- a/scripts/lsrs.py
+++ b/scripts/lsrs.py
@@ -13,7 +13,7 @@ URL_DIRECTORY = "main/assets/iconfiles/IconSheets"
 ICON_DIRECTORY = f"{ICON_URL}{URL_DIRECTORY}"
 
 HEAD = """//Created by the NWS Central Region Convective Warning Improvement Project (CWIP Team)
-Refresh: 1
+RefreshSeconds: 5
 Threshold: 999
 Title: Local Storm Reports -- for radar simulation
 """

--- a/scripts/meso/plot/plots.py
+++ b/scripts/meso/plot/plots.py
@@ -76,7 +76,7 @@ def contour(lon, lat, data, time_str, timerange_str, **kwargs):
     
     out = []
     out.append('Title: %s -- for radar simulation\n' % (plotinfo))
-    out.append('RefreshSeconds: 60\n')
+    out.append('RefreshSeconds: 5\n')
     out.append('Font: 1, 14, 1, "Arial"\n')
     out.append('TimeRange: %s\n' % (timerange_str))
 
@@ -174,7 +174,7 @@ def contour(lon, lat, data, time_str, timerange_str, **kwargs):
 
     out = []
     out.append('Title: %s | %s\n' % (plotinfo, time_str))
-    out.append('RefreshSeconds: 60\n')
+    out.append('RefreshSeconds: 5\n')
     out.append('Font: 1, 14, 1, "Arial"\n')
     out.append('TimeRange: %s\n' % (timerange_str))
 
@@ -269,7 +269,7 @@ def contourf(lon, lat, data, time_str, timerange_str, **kwargs):
 
     out = []
     out.append('Title: %s Filled Contour -- for radar simulation\n' % (plotinfo))
-    out.append('RefreshSeconds: 60\n')
+    out.append('RefreshSeconds: 5\n')
     out.append('TimeRange: %s\n' % (timerange_str))
     rgb = hex2rgb(colors[0])
     for collection in c.collections:
@@ -481,7 +481,7 @@ def barbs(lon, lat, U, V, time_str, timerange_str, **kwargs):
     skip = kwargs.get('skip', 6)
     out = []
     out.append('Title: %s -- for radar simulation\n' % (plotinfo))
-    out.append('RefreshSeconds: 60\n')
+    out.append('RefreshSeconds: 5\n')
     out.append('TimeRange: %s\n' % (timerange_str))
     out.append('Color: 255 255 255\n')
     out.append('IconFile: 1, 28, 28, 14, 14, "%s"\n' % (iconfile))
@@ -542,7 +542,7 @@ def barbs_devtor(lon, lat, U, V, deviance, time_str, timerange_str, **kwargs):
     skip = kwargs.get('skip', 3)
     out = []
     out.append('Title: %s -- for radar simulation\n' % (plotinfo))
-    out.append('RefreshSeconds: 60\n')
+    out.append('RefreshSeconds: 5\n')
     out.append('TimeRange: %s\n' % (timerange_str))
     out.append('Color: 255 255 255\n')
     out.append('IconFile: 1, 28, 28, 14, 14, "%s"\n' % (iconfile))

--- a/scripts/obs_placefile.py
+++ b/scripts/obs_placefile.py
@@ -38,7 +38,7 @@ FONT_CODE = 2
 WIND_ICON_NUMBER = 1
 GUST_DISTANCE = 35
 
-ICON_FONT_TEXT = '\n\nRefresh: 1\
+ICON_FONT_TEXT = '\n\nRefreshSeconds: 5\
         \nColor: 255 200 255\
         \nIconFile: 1, 18, 32, 2, 31, "https://mesonet.agron.iastate.edu/request/grx/windbarbs.png"\
         \nIconFile: 2, 15, 15, 8, 8, "https://mesonet.agron.iastate.edu/request/grx/cloudcover.png"\

--- a/scripts/probsevere_placefile.py
+++ b/scripts/probsevere_placefile.py
@@ -74,7 +74,7 @@ class ProbSeverePlacefile:
         
         """
         with open(self.placefile_path, 'w', encoding='utf-8') as pf:
-            pf.write('Title: ProbSevere objects loop -- for radar simulation\nRefresh: 1\n\n')
+            pf.write('Title: ProbSevere objects loop -- for radar simulation\nRefreshSeconds: 5\n\n')
             for n, file in enumerate(self.files):
                 timrange_line = f"{self.timerange_lines[n]}\n\n"
                 pf.write(timrange_line)


### PR DESCRIPTION
Main update was to add a button within the Simulation Launch and Playback Controls GUI called "Refresh Polling Times".  Clicking this will force l2munger to regenerate radar files based on the current real-world time to allow a user to continue a simulation if they've left things dormant for a while. Hodographs are regenerated, placefiles are re-shifted (in time), and the events_time.txt file is updated. 

Additional items are:

- User can only click the refresh button if the playback has been paused
- User is forced to click the Launch Simulation button once the refresh has been completed. This is to "reprime" the simulation controls. 
- Fix to allow GR to show placefiles on the most recent volume scan
- Changed placefile refresh time to 5 seconds (previous was 1 minute). 
- Remove sim files each time a user clicks the run scripts button to clear out old data. This was impacting what was being (incorrectly) reported by the monitor function. 
- Attempt to suppress flask output in scripts logfile (i.e. "POST /_dash-update-component HTTP/1.1" 200 to scripts.log)