### PR TITLE
Various patches/improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -251,6 +251,12 @@ def remove_files_and_dirs(cfg) -> None:
             for name in dirs:
                 os.rmdir(os.path.join(root, name))
 
+    # Remove the original file_times.txt file. This will get re-created by munger.py
+    try:
+        os.remove(f"{cfg['ASSETS_DIR']}/file_times.txt")
+    except FileNotFoundError:
+        pass
+
 
 def remove_munged_radar_files(cfg) -> None:
     """

--- a/app.py
+++ b/app.py
@@ -783,14 +783,6 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
     This version of the script-launcher trying to work in cancel button
     """
     UpdateHodoHTML('None', cfg['HODOGRAPHS_DIR'], cfg['HODOGRAPHS_PAGE'])
-    # writes a black event_times.txt file to the assets directory
-    args = [str(sim_times['simulation_seconds_shift']), 'None', cfg['RADAR_DIR'],
-            cfg['EVENTS_HTML_PAGE'], cfg['EVENTS_TEXT_FILE']]
-    res = call_function(utils.exec_script, Path(cfg['EVENT_TIMES_SCRIPT_PATH']), args,
-                        cfg['SESSION_ID'])
-    if res['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
-        return
-
 
     # based on list of selected radars, create a dictionary of radar metadata
     try:

--- a/app.py
+++ b/app.py
@@ -978,7 +978,8 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
 
 
 @app.callback(
-    Output('show_script_progress', 'children', allow_duplicate=True),
+    #Output('show_script_progress', 'children', allow_duplicate=True),
+    Output('sim_times', 'data', allow_duplicate=True),
     [Input('run_scripts_btn', 'n_clicks'),
      State('configs', 'data'),
      State('sim_times', 'data'),
@@ -1010,6 +1011,11 @@ def launch_simulation(n_clicks, configs, sim_times, radar_info):
     This function is called when the "Run Scripts" button is clicked. It will execute the
     necessary scripts to simulate radar operations, create hodographs, and transpose placefiles.
     """
+    # Update the simulation times. 
+    event_dt = datetime.strptime(sim_times['event_start_str'], '%Y-%m-%d %H:%M')
+    event_dt = pytz.utc.localize(event_dt)
+    sim_times = make_simulation_times(event_dt, sim_times['event_duration'])
+
     if n_clicks == 0:
         raise PreventUpdate
     else:
@@ -1024,6 +1030,8 @@ def launch_simulation(n_clicks, configs, sim_times, radar_info):
             #     print(f"Failed to send email: {e}")
             remove_files_and_dirs(configs)
             run_with_cancel_button(configs, sim_times, radar_info)
+    
+    return sim_times
 
 ################################################################################################
 # ----------------------------- Monitoring and reporting script status  ------------------------

--- a/app.py
+++ b/app.py
@@ -1203,6 +1203,7 @@ def run_transpose_script(PLACEFILES_DIR, sim_times, radar_info) -> None:
     Output('speed_dropdown', 'disabled'),
     Output('playback_specs', 'data', allow_duplicate=True),
     Output('refresh_polling_btn', 'disabled', allow_duplicate=True),
+    Output('run_scripts_btn', 'disabled', allow_duplicate=True),
     [Input('playback_btn', 'n_clicks'),
      State('playback_speed_store', 'data'),
      State('configs', 'data'),
@@ -1248,11 +1249,13 @@ def initiate_playback(_nclick, playback_speed, cfg, sim_times, radar_info):
                     radar, sim_times['playback_clock_str'], cfg['POLLING_DIR'])
 
     refresh_polling_btn_disabled = False
+    run_scripts_btn_disabled = False
     if playback_running:
         refresh_polling_btn_disabled = True
+        run_scripts_btn_disabled = True
 
     return (btn_text, btn_disabled, False, playback_running, start, style, end, style, options,
-            False, playback_specs, refresh_polling_btn_disabled)
+            False, playback_specs, refresh_polling_btn_disabled, run_scripts_btn_disabled)
 
 
 @app.callback(
@@ -1264,6 +1267,7 @@ def initiate_playback(_nclick, playback_speed, cfg, sim_times, radar_info):
     Output('current_readout', 'style'),
     Output('playback_specs', 'data', allow_duplicate=True),
     Output('refresh_polling_btn', 'disabled', allow_duplicate=True),
+    Output('run_scripts_btn', 'disabled', allow_duplicate=True),
     [Input('pause_resume_playback_btn', 'n_clicks'),
      Input('playback_timer', 'n_intervals'),
      Input('change_time', 'value'),
@@ -1398,11 +1402,13 @@ def manage_clock_(nclicks, _n_intervals, new_time, _playback_running, playback_s
     specs['style'] = style
 
     refresh_polling_btn_disabled = True
+    run_scripts_btn_disabled = True
     if playback_paused:
         refresh_polling_btn_disabled = False
+        run_scripts_btn_disabled = False
     return (specs['interval_disabled'], specs['status'], specs['style'],
             specs['playback_btn_text'], readout_time, style, specs,
-            refresh_polling_btn_disabled)
+            refresh_polling_btn_disabled, run_scripts_btn_disabled)
 
 ################################################################################################
 # ----------------------------- Playback Speed Callbacks  --------------------------------------

--- a/app.py
+++ b/app.py
@@ -1706,7 +1706,7 @@ def make_events_placefile(contents, filename, cfg):
     """
     This function creates the Event Notification placefile for the radar simulation
     """
-    top_section = 'Refresh: 1\
+    top_section = 'RefreshSeconds: 5\
     \nThreshold: 999\
     \nTitle: Event Notifications -- for radar simulation\
     \nColor: 255 200 255\

--- a/app.py
+++ b/app.py
@@ -262,7 +262,9 @@ def remove_munged_radar_files(cfg) -> None:
     downloaded by the user if desired.
     """
     regex_pattern = r'^(.{4})(\d{8})_(\d{6})$'
-    raw_pattern = r'^(.{4})(\d{8})_(\d{6})_(V\d{2})$'
+    #raw_pattern = r'^(.{4})(\d{8})_(\d{6})_(V\d{2})$'
+    # Searches for filenames with either Vxx or .gz. Older radar files are gzipped.
+    raw_pattern = r'^.{4}\d{8}_\d{6}(_V\d{2}|\.gz)$'
     for root, _, files in os.walk(cfg['RADAR_DIR']):
         if Path(root).name == 'downloads':
             for name in files:

--- a/app.py
+++ b/app.py
@@ -996,9 +996,9 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
         (Output('new_radar_selection', 'disabled'), True, False),
         (Output('run_scripts_btn', 'disabled'), True, False),
         # (Output('playback_clock_store', 'disabled'), True, False),
-        (Output('confirm_radars_btn', 'disabled'),
-         True, False),  # added radar confirm btn
+        (Output('confirm_radars_btn', 'disabled'), True, False),  # added radar confirm btn
         (Output('playback_btn', 'disabled'), True, False),  # add start sim btn
+        (Output('playback_btn', 'children'), 'Launch Simulation', 'Launch Simulation'), 
         (Output('refresh_polling_btn', 'disabled'), True, False),
         (Output('pause_resume_playback_btn', 'disabled'), True, True), # add pause/resume btn
         # wait to enable change time dropdown

--- a/app.py
+++ b/app.py
@@ -1508,6 +1508,14 @@ def refresh_polling(n_clicks, cfg, sim_times, radar_info):
     except FileNotFoundError:
         pass
 
+    # Delete the uncompressed/munged radar files from the data directory. Needed if a user
+    # canceled a previous refresh before mungering finishes, leaving orphaned .uncompressed
+    # files in the radar data directory.
+    try:
+        remove_munged_radar_files(cfg)
+    except KeyError as e:
+        logging.exception("Error removing munged radar files ", exc_info=True)
+
     # --------- Munger ---------------------------------------------------------
     # This for loop removes the now-stale munged radar files. We do this in a 
     # first loop  to delete all of the files at once. Otherwise, the monitor bar 

--- a/config.py
+++ b/config.py
@@ -143,8 +143,8 @@ def setup_paths_and_dirs(n_intervals, session_id):
 
 # Names (without extensions) of various pre-processing scripts. Needed for script
 # monitoring and/or cancelling.
-scripts_list = ["Nexrad", "munger", "obs_placefile", "nse", "wgrib2",
-                "get_data", "process", "hodo_plot"]
+scripts_list = ["Nexrad", "munger", "lsrs", "obs_placefile", "ProbSevere", "probsevere_placefile", 
+                "nse", "wgrib2", "get_data", "process", "hodo_plot"]
 
 # Names of surface placefiles for monitoring script
 surface_placefiles = [

--- a/scripts/munger.py
+++ b/scripts/munger.py
@@ -101,9 +101,10 @@ class Munger():
                 # unsure if ungzip'ed file needs to be passed to debz.py
                 # Edit 6/28: keep original compressed file used for radar status tracking.
                 filename_str = filename_str[:-3]
-                cp_command_str = f'cp {filename_str} {self.user_downloads_dir}/{filename_str}'
-                print(cp_command_str)
-                os.system(cp_command_str)
+                # The following commands were erroring out (no .gz extension specified). 
+                # Not needed anymore, since copying is handled in app.py.
+                #cp_command_str = f'cp {filename_str} {self.user_downloads_dir}/{filename_str}'
+                #os.system(cp_command_str)
                 new_filename = f'{filename_str}.uncompressed'
                 command_string = f'gunzip -c {filename_str} > {new_filename}'
                 os.system(command_string)


### PR DESCRIPTION
Various patches and general improvements:

- Fixes #60 
- events.txt (and events_shifted.txt and events_updated.txt) update at 5 second intervals, like the rest of the placefiles. Was slightly delaying proctor injects. 
- User can no longer click Run Scripts when a simulation is running. 
- Simulation times are now refreshed to the current time when the run scripts button is clicked.  Previously, this only happened when time dropdowns were selected. 
- If a user had previously run a sim, but now has re-run scripts, the launch simulation button is now correctly re-set to say "Launch Simulation" instead of "Simulation Launched". 
- Older (gzipped) radar files are now correctly copied to the assets/downloads directory. 

A minor item that will need to be addressed in a future PR: If a user hits the cancel scripts button while the refresh polling scripts are running, dash throws the following exception:

```
Expected type: (<class 'tuple'>, <class 'list'>)
Received value of type <class 'NoneType'>:
    None
```

This seems to be because refresh_polling returns None as it's terminated prior to being able to return anything.  This will not impact the application, but will clutter the log file up a bit. This will be fixed in a separate patch to address lingering buttonology improvements. 