### PR TITLE
Bugfix/times

### DIFF
--- a/app.py
+++ b/app.py
@@ -1009,7 +1009,7 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
         (Output('pause_resume_playback_btn', 'disabled'), True, True), # add pause/resume btn
         # wait to enable change time dropdown
         (Output('change_time', 'disabled'), True, False),
-        (Output('cancel_scripts', 'disabled'), False, True),
+        (Output('cancel_scripts', 'disabled'), False, False),
     ])
 def coordinate_preprocessing_and_refresh(sim_times, configs, radar_info):
     """

--- a/app.py
+++ b/app.py
@@ -1242,6 +1242,18 @@ def run_transpose_script(PLACEFILES_DIR, sim_times, radar_info) -> None:
 ################################################################################################
 # ----------------------------- Clock Callbacks  -----------------------------------------------
 ################################################################################################
+def check_dirlist_sizes(POLLING_DIR):      
+    """
+    Checks and returns the size of all dir.list files in the polling directory. 
+    """
+    base = Path(POLLING_DIR)
+    dir_list_files = list(base.glob("*/dir.list"))
+    dir_list_sizes = {}
+    for f in dir_list_files:
+        radar_name = f.parent.name
+        size = f.stat().st_size
+        dir_list_sizes[radar_name] = size
+    return dir_list_sizes
 
 
 @app.callback(
@@ -1269,6 +1281,17 @@ def initiate_playback(_nclick, playback_speed, cfg, sim_times, radar_info):
     Enables/disables interval component that elapses the playback time. User can only 
     click this button this once.
     """
+    # Report out the size of the dir.list files in the polling directory. This is done
+    # first just in case no radar directories are found (shouldn't happen, but just in case), 
+    # which would result in FileNotFoundErrors in UpdateDirList() calls.
+    dir_list_sizes = check_dirlist_sizes(cfg['POLLING_DIR'])
+    log_string = (
+        f"\n"
+        f"*************************Playback Launched**************************\n"
+        f"Session ID: {cfg['SESSION_ID']}\n"
+        f"dir.list sizes (in bytes): {dir_list_sizes}\n"
+    )
+    logging.info(log_string)
 
     playback_specs = {
         'playback_paused': False,
@@ -1310,8 +1333,6 @@ def initiate_playback(_nclick, playback_speed, cfg, sim_times, radar_info):
 
     log_string = (
         f"\n"
-        f"*************************Playback Launched**************************\n"
-        f"Session ID: {cfg['SESSION_ID']}\n"
         f"Start: {sim_times['playback_start_str']}, End: {sim_times['playback_end_str']}\n"
         f"Start dt: {sim_times['playback_start']}, End dt: {sim_times['playback_end']}\n"
         f"Launch Simulation Button Disabled?: {btn_disabled}\n"

--- a/app.py
+++ b/app.py
@@ -924,7 +924,7 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
                         cfg['SESSION_ID'])
     if res['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
-    '''
+
     # --------- NSE placefiles ------------------------------------------------------
     args = [str(sim_times['event_start_str']), str(sim_times['event_duration']),
             cfg['SCRIPTS_DIR'], cfg['DATA_DIR'], cfg['PLACEFILES_DIR']]
@@ -932,7 +932,7 @@ def run_with_cancel_button(cfg, sim_times, radar_info):
                         cfg['SESSION_ID'])
     if res['returncode'] in [signal.SIGTERM, -1*signal.SIGTERM]:
         return
-    '''
+
     # Now that all original placefiles should be available, zip them up
     try:
         zip_original_placefiles(cfg)

--- a/layout_components.py
+++ b/layout_components.py
@@ -111,10 +111,12 @@ monthnames = ["January", "February", "March", "April", "May", "June", "July", "A
 
 top_section = html.Div([], style={'height': '5px'})
 
-
+WARNING_TEXT = "The application is undergoing testing and maintenance. Simulations won't be available. We apologize for the inconvenience!"
 top_content = [
     dbc.CardBody([html.H2("Radar Simulation Server in the Cloud", className="card-title",
                           style={'font-weight': 'bold', 'font-style': 'italic'}),
+                  html.H2(WARNING_TEXT, className="card-title",
+                          style={'font-weight': 'bold', 'color': 'red'}),
                   html.H5(
         "Providing radar simulations for NOAA/NWS training ...",
         className="card-text", style={'color': 'rgb(52,152,219)', 'font-weight': 'bold',

--- a/layout_components.py
+++ b/layout_components.py
@@ -111,12 +111,12 @@ monthnames = ["January", "February", "March", "April", "May", "June", "July", "A
 
 top_section = html.Div([], style={'height': '5px'})
 
-WARNING_TEXT = "The application is undergoing testing and maintenance. Simulations won't be available. We apologize for the inconvenience!"
+#WARNING_TEXT = "The application is undergoing testing and maintenance. Simulations won't be available. We apologize for the inconvenience!"
 top_content = [
     dbc.CardBody([html.H2("Radar Simulation Server in the Cloud", className="card-title",
                           style={'font-weight': 'bold', 'font-style': 'italic'}),
-                  html.H2(WARNING_TEXT, className="card-title",
-                          style={'font-weight': 'bold', 'color': 'red'}),
+                  #html.H2(WARNING_TEXT, className="card-title",
+                  #        style={'font-weight': 'bold', 'color': 'red'}),
                   html.H5(
         "Providing radar simulations for NOAA/NWS training ...",
         className="card-text", style={'color': 'rgb(52,152,219)', 'font-weight': 'bold',


### PR DESCRIPTION
Moved the broadcasting of `sim_times` to a standalone callback, which executes on run_scripts_btn or refresh_polling_btn clicks. This ensures the sim_times store object is immediately updated.  Previously, this occurred at the end of a very long running callback, which was not guaranteed to broadcast this information (due to behind-the-scenes 504 timeout or a user cancelling scripts). 

Testing suggests this has fully solved the 15-minute bug. 

Coordination of pre-processing and resh-polling scripts has been centralized in a single callback for simplification. 

The silent 504 Timeout Error persists, and occurs after a callback runs for more than ~5 minutes.  Protecting against issues by keeping the cancel scripts button active at all times. 